### PR TITLE
Added client-side and server-side validation for letters only

### DIFF
--- a/client/clientSocket.js
+++ b/client/clientSocket.js
@@ -24,6 +24,10 @@ function setUsername(username) {
 }
 
 function submitGuess(letter) {
+	if (/[^a-zA-Z]/.test(letter)) {
+		gameMessage.innerHTML = "You can only make a guess using letters."
+		return;
+	}
 	let guessFound = userGuesses.innerHTML.split(',').find((guess) => {
       return guess === letter;
     });

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -36,7 +36,11 @@ export class Server {
         socket.username = username;
       });
 
-      socket.on('newGuess', function(letter){
+      socket.on('newGuess', function(submittedLetter){
+        // If they remove client-side validation and submit a non-letter, then we make the guess blank
+        // and count it against their score. This way, all non-letter submissions are treated as the
+        // same character.
+        const letter = submittedLetter.replace(/[^a-zA-Z]/g, '');
         let guess = game.newGuess(letter);
         socket.emit(guess, game.getState(socket.username));
         socket.broadcast.emit(guess, game.getState(socket.username));


### PR DESCRIPTION
If a non-letter is entered, the user will receive a message telling them to only use letters. If they were to bypass the front-end javascript, then we replace the character (on the server) with nothing and count that as a "try".

Closes #36 